### PR TITLE
ci: add jobs for pre-commit and running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: pre-commit/action@v3.0.0
+
+  tests:
+    runs-on: ubuntu-latest
+    name: Test Python ${{ matrix.python-version }}
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package
+        run: python -m pip install .[test]
+
+      - name: Test package
+        run: python -m pytest


### PR DESCRIPTION
Hi! I created this ci.yml file and included the same things that we talked about in class and in the most recent homework assignment (a lint/formatting job and a job to run the tests). The only other thing I did was included a line to run the workflow on workflow_dispatch so that we can manually run the CI if we wanted to.

Please let me know if you think there is anything else worth including! Also, what versions of python do we want to run on? And, currently I am only running the tests on ubuntu-latest and was wondering if we should also run on windows-latest?

Thanks!